### PR TITLE
fix(ci): skip --localstorage-file flag on Node < 22

### DIFF
--- a/scripts/runJest.js
+++ b/scripts/runJest.js
@@ -6,8 +6,9 @@ const jestBin = require.resolve('jest/bin/jest');
 const localStorageFile = path.join(os.tmpdir(), 'sql-crack-localstorage');
 
 const existingNodeOptions = process.env.NODE_OPTIONS || '';
+const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
 const hasLocalStorageOption = existingNodeOptions.split(/\s+/).some((opt) => opt.startsWith('--localstorage-file'));
-const nextNodeOptions = hasLocalStorageOption
+const nextNodeOptions = (hasLocalStorageOption || nodeMajor < 22)
   ? existingNodeOptions
   : [existingNodeOptions, `--localstorage-file=${localStorageFile}`].filter(Boolean).join(' ');
 


### PR DESCRIPTION
The flag is only available in Node 22+, causing exit code 9 on CI runners using Node 18.x and 20.x.

## Description
Brief description of the changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Describe how you tested these changes.

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added tests (if applicable)
- [ ] My code follows the project's style guidelines
- [ ] I have updated documentation (if applicable)
