### PR TITLE
fix: respect defaultTheme setting in SQL Flow webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-02-11
+
+### Fixed
+
+- **SQL Flow theme ignoring `defaultTheme` setting**: The SQL Flow webview always opened in dark mode regardless of the `sqlCrack.advanced.defaultTheme` setting. The extension host now reads the setting (matching the workspace panel behavior), and the renderer initializes `isDarkTheme` from `window.vscodeTheme` instead of hardcoding `true`.
+
+### Tests
+
+- Added regression tests for SQL Flow theme initialization: verifies `visualizationPanel.ts` reads `advanced.defaultTheme` and `renderer.ts` initializes theme from `window.vscodeTheme`.
+
 ## [0.3.3] - 2026-02-11
 
 ### Added
@@ -539,6 +549,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+[0.3.4]: https://github.com/buva7687/sql-crack/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/buva7687/sql-crack/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/buva7687/sql-crack/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/buva7687/sql-crack/compare/v0.3.0...v0.3.1

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sql-crack",
   "displayName": "SQL Crack",
   "description": "Visualize SQL queries with interactive flow diagrams",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "publisher": "buvan",
   "repository": {

--- a/src/visualizationPanel.ts
+++ b/src/visualizationPanel.ts
@@ -463,11 +463,21 @@ export class VisualizationPanel {
 
         const nonce = getNonce();
 
+        const config = vscode.workspace.getConfiguration('sqlCrack');
+
         const themeKind = vscode.window.activeColorTheme.kind;
-        const vscodeTheme = themeKind === vscode.ColorThemeKind.Light || themeKind === vscode.ColorThemeKind.HighContrastLight ? 'light' : 'dark';
         const isHighContrast = themeKind === vscode.ColorThemeKind.HighContrast || themeKind === vscode.ColorThemeKind.HighContrastLight;
 
-        const config = vscode.workspace.getConfiguration('sqlCrack');
+        const themePreference = config.get<string>('advanced.defaultTheme', 'light');
+        let vscodeTheme: string;
+        if (themePreference === 'light') {
+            vscodeTheme = 'light';
+        } else if (themePreference === 'dark') {
+            vscodeTheme = 'dark';
+        } else {
+            // 'auto' - match VS Code theme
+            vscodeTheme = themeKind === vscode.ColorThemeKind.Light || themeKind === vscode.ColorThemeKind.HighContrastLight ? 'light' : 'dark';
+        }
         const viewLocation = config.get<ViewLocation>('viewLocation') || 'tab';
         const defaultLayout = config.get<string>('defaultLayout') || 'vertical';
         const flowDirection = config.get<string>('flowDirection') || 'top-down';

--- a/src/webview/renderer.ts
+++ b/src/webview/renderer.ts
@@ -124,7 +124,7 @@ const state: ViewState = {
     legendVisible: true,
     highlightedColumnSources: [],
     isFullscreen: false,
-    isDarkTheme: true,
+    isDarkTheme: window.vscodeTheme !== 'light',
     isHighContrast: false,
     breadcrumbPath: [],
     showColumnLineage: false,

--- a/tests/unit/webview/sqlFlowThemeInit.test.ts
+++ b/tests/unit/webview/sqlFlowThemeInit.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('SQL Flow theme initialization respects defaultTheme setting', () => {
+    const panelSource = readFileSync(
+        join(__dirname, '../../../src/visualizationPanel.ts'),
+        'utf8'
+    );
+    const rendererSource = readFileSync(
+        join(__dirname, '../../../src/webview/renderer.ts'),
+        'utf8'
+    );
+
+    describe('visualizationPanel.ts', () => {
+        it('reads the advanced.defaultTheme setting', () => {
+            expect(panelSource).toContain("config.get<string>('advanced.defaultTheme'");
+        });
+
+        it('maps light/dark/auto preference to vscodeTheme value', () => {
+            expect(panelSource).toContain("themePreference === 'light'");
+            expect(panelSource).toContain("themePreference === 'dark'");
+            // 'auto' falls through to VS Code theme detection
+            expect(panelSource).toContain("// 'auto' - match VS Code theme");
+        });
+
+        it('does not hardcode vscodeTheme directly from activeColorTheme without checking setting', () => {
+            // vscodeTheme must be declared with let (computed conditionally), not const from theme kind
+            expect(panelSource).toContain('let vscodeTheme: string;');
+            expect(panelSource).not.toMatch(
+                /const vscodeTheme\s*=\s*themeKind\s*===/
+            );
+        });
+    });
+
+    describe('renderer.ts', () => {
+        it('initializes isDarkTheme from window.vscodeTheme instead of hardcoding true', () => {
+            expect(rendererSource).toContain("isDarkTheme: window.vscodeTheme !== 'light'");
+            expect(rendererSource).not.toMatch(/isDarkTheme:\s*true\s*,/);
+        });
+    });
+});


### PR DESCRIPTION
visualizationPanel.ts now reads advanced.defaultTheme (light/dark/auto) instead of always using the active VS Code theme. renderer.ts initializes isDarkTheme from window.vscodeTheme instead of hardcoding true.

## Description
Brief description of the changes.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
Describe how you tested these changes.

## Checklist
- [ ] I have tested my changes locally
- [ ] I have added tests (if applicable)
- [ ] My code follows the project's style guidelines
- [ ] I have updated documentation (if applicable)
