### PR TITLE
fix: strip OPENJSON WITH schema clause before parsing (issue #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-05-31
+
+### Fixed
+
+- **SQL Server `OPENJSON WITH` compatibility** ([#82](https://github.com/buva7687/sql-crack/issues/82)): TransactSQL preprocessing now strips `OPENJSON(...) WITH (...)` schema clauses before AST parsing while preserving the `OPENJSON` table-valued function node for visualization.
+
+### Tests
+
+- Added regression coverage for `OPENJSON WITH` schema clauses in SQL Server `CROSS APPLY` queries, including multiple typed output columns and compatibility-hint coverage.
+
 ## [0.8.1] - 2026-04-25
 
 ### Changed

--- a/examples/tvf-transactsql.sql
+++ b/examples/tvf-transactsql.sql
@@ -36,3 +36,16 @@ SELECT
 FROM orders o
 CROSS APPLY OPENJSON(o.tags) AS t
 ORDER BY o.order_id, t.[key];
+
+-- Q4: OPENJSON with explicit schema (WITH clause) — issue #82
+SELECT SalesOrderID, OrderDate, value AS Reason
+FROM Sales.SalesOrderHeader
+     CROSS APPLY OPENJSON(SalesReasons) WITH (value NVARCHAR(100) '$');
+
+-- Q5: OPENJSON WITH clause with multiple typed columns
+SELECT o.order_id, item.sku, item.qty
+FROM dbo.Orders o
+CROSS APPLY OPENJSON(o.payload) WITH (
+    sku NVARCHAR(50) '$.sku',
+    qty INT          '$.qty'
+) AS item;

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1810,7 +1809,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2471,7 +2469,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2825,7 +2822,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3382,7 +3378,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4448,7 +4443,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -6280,7 +6274,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6910,7 +6903,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7081,7 +7073,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -7131,7 +7122,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sql-crack",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sql-crack",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "d3-force": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sql-crack",
   "displayName": "SQL Crack",
   "description": "Visualize SQL queries with interactive flow diagrams",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "license": "MIT",
   "publisher": "buvan",
   "repository": {

--- a/src/webview/parser/dialects/preprocessing.ts
+++ b/src/webview/parser/dialects/preprocessing.ts
@@ -2010,7 +2010,7 @@ function stripDoubleColonCasts(sql: string): string | null {
  * Order mirrors `applyParserCompatibilityPreprocessing()` in sqlParser.ts:
  * 1. CTE hoisting (all dialects)
  * 2. PostgreSQL syntax (AT TIME ZONE, type-prefixed literals)
- * 3. TransactSQL syntax (AT TIME ZONE, TRY_CAST)
+ * 3. TransactSQL syntax (AT TIME ZONE, TRY_CAST, OPENJSON WITH)
  * 4. Redshift syntax (SELECT INTO, late-binding views, CTAS physical options)
  * 5. GROUPING SETS rewrite (all dialects)
  * 6. Oracle syntax ((+), MINUS, CONNECT BY, PIVOT, FLASHBACK, MODEL, RETURNING INTO)

--- a/src/webview/parser/dialects/preprocessing.ts
+++ b/src/webview/parser/dialects/preprocessing.ts
@@ -115,11 +115,70 @@ export function preprocessPostgresSyntax(sql: string, dialect: SqlDialect): stri
 }
 
 /**
+ * Strip `OPENJSON(...) WITH (col type 'path', ...)` schema clauses.
+ *
+ * The WITH clause is T-SQL-specific syntax that defines the output schema of OPENJSON.
+ * node-sql-parser does not recognise it and raises a parse error. Stripping it leaves
+ * a plain `OPENJSON(...)` call which the parser handles as a normal table-valued function.
+ */
+function stripOpenJsonWithClauses(sql: string): string | null {
+    const masked = maskStringsAndComments(sql);
+    const openjsonRegex = /\bOPENJSON\s*\(/gi;
+    const removals: Array<{ start: number; end: number }> = [];
+    let match: RegExpExecArray | null;
+
+    while ((match = openjsonRegex.exec(masked)) !== null) {
+        // Find position of the opening paren of OPENJSON(...)
+        const openParenPos = match.index + match[0].length - 1;
+        const closeParenPos = findMatchingParen(sql, openParenPos);
+        if (closeParenPos === -1) {
+            continue;
+        }
+
+        // Skip whitespace after the closing paren
+        let pos = closeParenPos + 1;
+        while (pos < masked.length && /\s/.test(masked[pos])) {
+            pos++;
+        }
+
+        // Check if the next token is WITH followed by (
+        if (!/^WITH\s*\(/i.test(masked.slice(pos))) {
+            continue;
+        }
+
+        const withStart = pos;
+        pos += masked.slice(pos).match(/^WITH\s*/i)![0].length;
+        if (pos >= masked.length || masked[pos] !== '(') {
+            continue;
+        }
+
+        const withCloseParenPos = findMatchingParen(sql, pos);
+        if (withCloseParenPos === -1) {
+            continue;
+        }
+
+        removals.push({ start: withStart, end: withCloseParenPos + 1 });
+    }
+
+    if (removals.length === 0) {
+        return null;
+    }
+
+    let result = sql;
+    for (let i = removals.length - 1; i >= 0; i--) {
+        const r = removals[i];
+        result = result.substring(0, r.start) + result.substring(r.end);
+    }
+    return result;
+}
+
+/**
  * Preprocess SQL Server-specific syntax that node-sql-parser doesn't support.
  *
  * Rewrites:
  * 1. `AT TIME ZONE 'tz'` - removed (timezone projection doesn't affect structure)
  * 2. `TRY_CAST(expr AS type)` → `CAST(expr AS type)` for structural parsing
+ * 3. `OPENJSON(...) WITH (col type 'path', ...)` — WITH schema clause stripped
  *
  * Returns the transformed SQL or `null` if no rewriting was needed.
  */
@@ -134,6 +193,12 @@ export function preprocessTransactSqlSyntax(sql: string, dialect: SqlDialect): s
     const strippedAtTimeZoneSql = stripAtTimeZoneClauses(result);
     if (strippedAtTimeZoneSql !== null) {
         result = strippedAtTimeZoneSql;
+        changed = true;
+    }
+
+    const strippedOpenJsonWith = stripOpenJsonWithClauses(result);
+    if (strippedOpenJsonWith !== null) {
+        result = strippedOpenJsonWith;
         changed = true;
     }
 

--- a/src/webview/sqlParser.ts
+++ b/src/webview/sqlParser.ts
@@ -1047,8 +1047,8 @@ function applyParserCompatibilityPreprocessing(
         transformedSql = transactSqlPreprocessedSql;
         pushHintOnce(context, {
             type: 'info',
-            message: 'Rewrote SQL Server-specific syntax (AT TIME ZONE, TRY_CAST) for parser compatibility',
-            suggestion: 'SQL Server constructs like AT TIME ZONE and TRY_CAST are valid in TransactSQL but unsupported by the parser. They were automatically simplified for visualization.',
+            message: 'Rewrote SQL Server-specific syntax (AT TIME ZONE, TRY_CAST, OPENJSON WITH) for parser compatibility',
+            suggestion: 'SQL Server constructs like AT TIME ZONE, TRY_CAST, and OPENJSON WITH schema clauses are valid in TransactSQL but unsupported by the parser. They were automatically simplified for visualization.',
             category: 'best-practice',
             severity: 'low',
         });

--- a/tests/unit/parser/lateralApply.test.ts
+++ b/tests/unit/parser/lateralApply.test.ts
@@ -82,6 +82,33 @@ describe('Item #5: LATERAL, CROSS APPLY, and OUTER APPLY Edge Cases', () => {
             expect(ordersTable).toBeDefined();
         });
 
+        it('should parse CROSS APPLY with OPENJSON WITH schema clause (issue #82)', () => {
+            const sql = `
+                SELECT SalesOrderID, OrderDate, value AS Reason
+                FROM Sales.SalesOrderHeader
+                     CROSS APPLY OPENJSON (SalesReasons) WITH (value NVARCHAR(100) '$')
+            `;
+            const result = parseSql(sql, 'TransactSQL' as SqlDialect);
+
+            expect(result.error).toBeUndefined();
+            expect(result.nodes.length).toBeGreaterThan(0);
+        });
+
+        it('should parse OPENJSON WITH multiple typed columns', () => {
+            const sql = `
+                SELECT o.order_id, item.sku, item.qty
+                FROM dbo.Orders o
+                CROSS APPLY OPENJSON(o.payload) WITH (
+                    sku NVARCHAR(50) '$.sku',
+                    qty INT          '$.qty'
+                ) AS item
+            `;
+            const result = parseSql(sql, 'TransactSQL' as SqlDialect);
+
+            expect(result.error).toBeUndefined();
+            expect(result.nodes.length).toBeGreaterThan(0);
+        });
+
         it('should parse CROSS APPLY with table-valued function', () => {
             const sql = `
                 SELECT *

--- a/tests/unit/parser/lateralApply.test.ts
+++ b/tests/unit/parser/lateralApply.test.ts
@@ -92,6 +92,10 @@ describe('Item #5: LATERAL, CROSS APPLY, and OUTER APPLY Edge Cases', () => {
 
             expect(result.error).toBeUndefined();
             expect(result.nodes.length).toBeGreaterThan(0);
+            expect(result.hints.some(hint =>
+                hint.message.includes('OPENJSON WITH')
+                || hint.suggestion?.includes('OPENJSON WITH')
+            )).toBe(true);
         });
 
         it('should parse OPENJSON WITH multiple typed columns', () => {

--- a/tests/unit/parser/preprocessing.test.ts
+++ b/tests/unit/parser/preprocessing.test.ts
@@ -214,6 +214,54 @@ describe('parser preprocessing transforms', () => {
             expect(preprocessTransactSqlSyntax('-- TRY_CAST(amount AS INT)\nSELECT amount FROM t', 'TransactSQL')).toBeNull();
             expect(preprocessTransactSqlSyntax('SELECT dbo.TRY_CAST(amount) FROM t', 'TransactSQL')).toBeNull();
         });
+
+        it('strips OPENJSON WITH schema clause', () => {
+            const sql = `SELECT SalesOrderID, OrderDate, value AS Reason
+FROM Sales.SalesOrderHeader
+     CROSS APPLY OPENJSON(SalesReasons) WITH (value NVARCHAR(100) '$')`;
+            const rewritten = preprocessTransactSqlSyntax(sql, 'TransactSQL');
+
+            expect(rewritten).not.toBeNull();
+            expect(rewritten).not.toMatch(/\bWITH\s*\(/i);
+            expect(rewritten).toContain('OPENJSON(SalesReasons)');
+            expect(rewritten).toContain('CROSS APPLY');
+        });
+
+        it('strips OPENJSON WITH clause with multiple columns', () => {
+            const sql = `SELECT id, name, qty
+FROM dbo.Orders o
+CROSS APPLY OPENJSON(o.payload) WITH (
+    id   INT          '$.id',
+    name NVARCHAR(50) '$.name',
+    qty  INT          '$.qty'
+) AS item`;
+            const rewritten = preprocessTransactSqlSyntax(sql, 'TransactSQL');
+
+            expect(rewritten).not.toBeNull();
+            expect(rewritten).not.toMatch(/\bWITH\s*\(/i);
+            expect(rewritten).toContain('OPENJSON(o.payload)');
+        });
+
+        it('strips multiple OPENJSON WITH clauses in one query', () => {
+            const sql = `SELECT a.v, b.v
+FROM t
+CROSS APPLY OPENJSON(t.col1) WITH (v NVARCHAR(10) '$') AS a
+CROSS APPLY OPENJSON(t.col2) WITH (v INT '$') AS b`;
+            const rewritten = preprocessTransactSqlSyntax(sql, 'TransactSQL');
+
+            expect(rewritten).not.toBeNull();
+            expect(rewritten).not.toMatch(/\bWITH\s*\(/i);
+            expect(rewritten).toContain('OPENJSON(t.col1)');
+            expect(rewritten).toContain('OPENJSON(t.col2)');
+        });
+
+        it('does not strip WITH from OPENJSON without a schema clause', () => {
+            const sql = `WITH cte AS (SELECT 1 AS val)
+SELECT * FROM OPENJSON((SELECT val FROM cte FOR JSON PATH)) AS j`;
+            const rewritten = preprocessTransactSqlSyntax(sql, 'TransactSQL');
+            // CTE WITH must be preserved; only OPENJSON(...) WITH (...) is stripped
+            expect(rewritten === null || (rewritten.includes('WITH cte AS'))).toBe(true);
+        });
     });
 
     describe('preprocessOracleSyntax — PIVOT/UNPIVOT', () => {


### PR DESCRIPTION
node-sql-parser does not recognise the T-SQL OPENJSON WITH clause that
defines an explicit output schema, e.g.:

  CROSS APPLY OPENJSON(col) WITH (value NVARCHAR(100) '$')

Add `stripOpenJsonWithClauses` inside `preprocessTransactSqlSyntax` to
remove the `WITH (...)` portion before handing the SQL to the parser.
The function call itself is preserved, so the OPENJSON node still
appears in the visualisation.

https://claude.ai/code/session_01FcCynEfuXCuRj4VukPFtMV